### PR TITLE
Apply loading animation to submit button when form submitted

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpserved.com/
 Tags: contact form, floating form, popup contact form, floating contact form, contact button, simple contact form
 Requires at least: 5.4
 Tested up to: 6.3
-Stable tag: 1.3.0.1
+Stable tag: 1.3.0.2
 Requires PHP: 7.2
 License: GNU General Public License v3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
@@ -49,6 +49,10 @@ You can find the plugin’s source code on our GitHub repo page. Feel free to pl
 1. So Simple! Sooo Easy!
 
 == Changelog ==
+= 1.3.0.2 =
+Add loading animation to submit button
+Declare position CSS property to form header
+
 = 1.3.0 =
 Add preview of uploaded icons
 Move custom icons upload fields to the "Style" tab

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpserved.com/
 Tags: contact form, floating form, popup contact form, floating contact form, contact button, simple contact form
 Requires at least: 5.4
 Tested up to: 6.3
-Stable tag: 1.3.0.2
+Stable tag: 1.4.0
 Requires PHP: 7.2
 License: GNU General Public License v3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
@@ -49,7 +49,7 @@ You can find the plugin’s source code on our GitHub repo page. Feel free to pl
 1. So Simple! Sooo Easy!
 
 == Changelog ==
-= 1.3.0.2 =
+= 1.4.0 =
 Add loading animation to submit button
 Declare position CSS property to form header
 

--- a/resources/assets/scripts/main.js
+++ b/resources/assets/scripts/main.js
@@ -81,6 +81,9 @@ jQuery(function($) {
             action: 'sfcf_send_form',
             page : window.location.href,
             inputs: $formData
+          },
+          beforeSend: function() {
+            $(e.originalEvent.submitter).addClass('-submitted');
           }
         })
 

--- a/resources/assets/styles/base/_general.scss
+++ b/resources/assets/styles/base/_general.scss
@@ -75,6 +75,7 @@ body {
       }
 
       &__header {
+        position: static;
         margin-top: 5px;
         margin-bottom: 24px;
       }

--- a/resources/assets/styles/base/_general.scss
+++ b/resources/assets/styles/base/_general.scss
@@ -75,7 +75,7 @@ body {
       }
 
       &__header {
-        position: static;
+        position: static !important;
         margin-top: 5px;
         margin-bottom: 24px;
       }

--- a/resources/assets/styles/components/_button.scss
+++ b/resources/assets/styles/components/_button.scss
@@ -108,8 +108,40 @@ body {
 
         &.-submit {
           margin-left: auto;
+
+          &.-submitted {
+            position: relative;
+            color: transparent;
+            pointer-events: none;
+
+            &::after {
+              content: "";
+              position: absolute;
+              width: 16px;
+              height: 16px;
+              top: 0;
+              left: 0;
+              right: 0;
+              bottom: 0;
+              margin: auto;
+              border: 4px solid transparent;
+              border-top-color: var(--sfcf-button-text);
+              border-radius: 50%;
+              animation: button-loading-spinner 1s ease infinite;
+            }
+          }
         }
       }
     }
+  }
+}
+
+@keyframes button-loading-spinner {
+  from {
+    transform: rotate(0turn);
+  }
+
+  to {
+    transform: rotate(1turn);
   }
 }

--- a/resources/views/layouts/main.php
+++ b/resources/views/layouts/main.php
@@ -130,7 +130,9 @@ $displayOptions = new Display();
             </fieldset>
           <?php endif; ?>
 
-          <input class="sfcf__button -submit" type="submit" value="<?php echo esc_attr($this->notes['submit']); ?>" />
+          <button class="sfcf__button -submit" type="submit">
+            <?php echo esc_attr($this->notes['submit']); ?>
+          </button>
         </form>
       </div>
 

--- a/simple-floating-contact-form.php
+++ b/simple-floating-contact-form.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpserved.com/
  * Text Domain: simple-floating-contact-form
  * Domain Path: /resources/lang
- * Version: 1.3.0.1
+ * Version: 1.3.0.2
  * Requires at least: 5.4
  * Requires PHP: 7.2
  */

--- a/simple-floating-contact-form.php
+++ b/simple-floating-contact-form.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpserved.com/
  * Text Domain: simple-floating-contact-form
  * Domain Path: /resources/lang
- * Version: 1.3.0.2
+ * Version: 1.4.0
  * Requires at least: 5.4
  * Requires PHP: 7.2
  */


### PR DESCRIPTION
This PR contains two changes for contact form styles:

1. The submit input is replaced with button, in order to allow putting the content inside the element (animated spinner). It is revealed after the form is submitted to indicate there is loading going on.
2. The position property is declared for form header to avoid accidental styles override, which results with the close button being unable to click.